### PR TITLE
v1.3.2 - Final patch - 'if' statement was reversed on ViewCamera zoom constructor

### DIFF
--- a/BassClefStudio.Graphics/BassClefStudio.Graphics.csproj
+++ b/BassClefStudio.Graphics/BassClefStudio.Graphics.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Description>A base library for managing cross-platform systems for drawing vector and turtle graphics, implemented in .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/Graphics-Libraries</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/Graphics-Libraries.git</RepositoryUrl>

--- a/BassClefStudio.Graphics/Core/ViewCamera.cs
+++ b/BassClefStudio.Graphics/Core/ViewCamera.cs
@@ -92,15 +92,15 @@ namespace BassClefStudio.Graphics.Core
             {
                 Transforms = new ITransform[]
                 {
-                    new Scaling(GetZoomFactor(viewSpace, drawSpace, zoomType))
+                    new Translation(viewSpace / 2),
+                    new Scaling(GetZoomFactor(viewSpace, drawSpace, zoomType), viewSpace / 2, true)
                 };
             }
             else
             {
                 Transforms = new ITransform[]
                 {
-                    new Translation(viewSpace / 2),
-                    new Scaling(GetZoomFactor(viewSpace, drawSpace, zoomType), viewSpace / 2, isCentered),
+                    new Scaling(GetZoomFactor(viewSpace, drawSpace, zoomType))
                 };
             }
         }


### PR DESCRIPTION
This should enable math-style zoomed `ViewCamera`s to be created with the correct centering in the view-space as well as reversed y-axis direction.