### PR TITLE
Basic SkiaSharp Support

### DIFF
--- a/BassClefStudio.Graphics.SkiaSharp/BassClefStudio.Graphics.SkiaSharp.csproj
+++ b/BassClefStudio.Graphics.SkiaSharp/BassClefStudio.Graphics.SkiaSharp.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>BassClefStudio.Graphics</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.2" />
+    <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BassClefStudio.Graphics\BassClefStudio.Graphics.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BassClefStudio.Graphics.SkiaSharp/Svg/SkiaSvgDocument.cs
+++ b/BassClefStudio.Graphics.SkiaSharp/Svg/SkiaSvgDocument.cs
@@ -1,0 +1,35 @@
+﻿using SkiaSharp.Extended.Svg;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.Graphics.Svg
+{
+    /// <summary>
+    /// Represents a Win2D loaded <see cref="ISvgDocument"/>.
+    /// </summary>
+    public class SkiaSvgDocument : ISvgDocument
+    {
+        /// <summary>
+        /// The attached <see cref="SKSvg"/>.
+        /// </summary>
+        public SKSvg SvgDocument { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="SkiaSvgDocument"/> from a Win2D <see cref="CanvasSvgDocument"/>.
+        /// </summary>
+        /// <param name="svgDocument">The attached <see cref="CanvasSvgDocument"/>.</param>
+        public SkiaSvgDocument(SKSvg svgDocument)
+        {
+            SvgDocument = svgDocument;
+        }
+
+        /// <inheritdoc/>
+        public string GetXml()
+        {
+            return SvgDocument.ToString();
+        }
+    }
+}

--- a/BassClefStudio.Graphics.Tests/BassClefStudio.Graphics.Tests.csproj
+++ b/BassClefStudio.Graphics.Tests/BassClefStudio.Graphics.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/BassClefStudio.Graphics.sln
+++ b/BassClefStudio.Graphics.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BassClefStudio.Graphics.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BassClefStudio.Graphics.Win2D", "BassClefStudio.Graphics.Win2D\BassClefStudio.Graphics.Win2D.csproj", "{AA5495C0-6A4B-42E9-8BAC-A3B6A9A4004B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BassClefStudio.Graphics.SkiaSharp", "BassClefStudio.Graphics.SkiaSharp\BassClefStudio.Graphics.SkiaSharp.csproj", "{563312D2-90E1-4F7E-B708-32F8DE6052D9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,26 @@ Global
 		{AA5495C0-6A4B-42E9-8BAC-A3B6A9A4004B}.Release|x64.Build.0 = Release|x64
 		{AA5495C0-6A4B-42E9-8BAC-A3B6A9A4004B}.Release|x86.ActiveCfg = Release|x86
 		{AA5495C0-6A4B-42E9-8BAC-A3B6A9A4004B}.Release|x86.Build.0 = Release|x86
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|ARM.Build.0 = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|x64.Build.0 = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Debug|x86.Build.0 = Debug|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|ARM.ActiveCfg = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|ARM.Build.0 = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|ARM64.Build.0 = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|x64.ActiveCfg = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|x64.Build.0 = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|x86.ActiveCfg = Release|Any CPU
+		{563312D2-90E1-4F7E-B708-32F8DE6052D9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BassClefStudio.Graphics/BassClefStudio.Graphics.csproj
+++ b/BassClefStudio.Graphics/BassClefStudio.Graphics.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BassClefStudio.NET.Core" Version="2.0.1" />
+    <PackageReference Include="BassClefStudio.NET.Core" Version="2.0.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/BassClefStudio.Graphics/Core/IGraphicsProvider.cs
+++ b/BassClefStudio.Graphics/Core/IGraphicsProvider.cs
@@ -11,7 +11,7 @@ namespace BassClefStudio.Graphics.Core
     /// <summary>
     /// Represents a drawable surface (either on an app <see cref="IGraphicsView"/>, or in a file) on which graphics commands can be executed.
     /// </summary>
-    public interface IGraphicsProvider
+    public interface IGraphicsProvider : IDisposable
     {
         /// <summary>
         /// The <see cref="ViewCamera"/> currently used by this <see cref="IGraphicsProvider"/> to shift between drawing- and view-space.


### PR DESCRIPTION
Includes new `.SkiaSharp` project with the `SkiaGraphicsProvider` providing turtle and SVG graphics similarly to how the `.Win2D` project works.

No views are included, because they need to be built on platform-specific projects (WPF, Windows.Forms, Xamarin, UWP, etc.), but the `SkiaGraphicsProvider` connects to the shared `SKCanvas` class on all of them.

When completed, closes #3.